### PR TITLE
feat(forecast): default units to f

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -47,7 +47,7 @@ app.get('/help', (req, res) => {
 
 // Fetching weather data based on address
 app.get('/weather', (req, res) => {
-    const {_, userUnits} = req.query;
+    const {_, units} = req.query;
     if (!req.query.address) {
         return res.send({
             error: 'You must provide an address'
@@ -69,7 +69,7 @@ app.get('/weather', (req, res) => {
                 location,
                 address: req.query.address
             })
-        }, userUnits)
+        }, units)
     })
 })
 

--- a/src/utils/forecast.js
+++ b/src/utils/forecast.js
@@ -1,6 +1,6 @@
 const request = require('request');
 
-const forecast = (latitude, longitude, callback, units) => {
+const forecast = (latitude, longitude, callback, units = 'f') => {
     const url = 'https://api.weatherstack.com/current?access_key=3de945378aaeff24c4d6636d4e484612&query=' + encodeURIComponent(latitude)+ ',' + encodeURIComponent(longitude) + "&units=" + units;
 
     // Makes a request to weatherstack and handles errors


### PR DESCRIPTION
- default the forecast unit to `f` - if the forecast receives units as undefined, it will always use "f" instead of failing.
- fix(typo): userUnits is not query param you're passing - you're passing `units`.

- TO_DO: Improve error message - it's not that it couldn't find location, in this case it was that the unit was missing, it was being sent like this: `&units=undefined` - so a better error message would be: "Invalid temperature unit, you must select celcius or farenheit"